### PR TITLE
perf: responsive markdown images; ci: gate on npm audit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,12 @@ jobs:
 
       - run: npm ci
 
+      # Fails the build on a known-vulnerable dependency. Nothing here ships to
+      # the browser, but the build toolchain is still worth keeping clean, and
+      # a fork that ignores Dependabot would otherwise never find out.
+      - name: Audit dependencies
+        run: npm audit --audit-level=high
+
       - name: Type check
         run: npm run check
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -20,6 +20,13 @@ export default defineConfig({
     plugins: [tailwindcss()],
   },
 
+  image: {
+    // Markdown images are already converted to WebP with explicit dimensions;
+    // this adds the srcset so a phone does not download a desktop-sized file.
+    layout: 'constrained',
+    responsiveStyles: true,
+  },
+
   build: {
     // Keep CSS in an external file rather than inlining small sheets, so the
     // Content-Security-Policy can use `style-src 'self'` for stylesheets


### PR DESCRIPTION
## Summary

Two small, verified fixes found while auditing the merged site. Both are one config change each.

## Responsive images

Astro already converts markdown images to WebP and emits explicit `width`/`height`, so layout shift was covered. But `srcset` was empty — a phone downloaded the full-resolution original.

Verified with an 800×600 fixture. Before:

```html
``&lt;img ... src="/_astro/test-image.…webp" srcset=""&gt;``
```

After:

```html
``&lt;img ... sizes="(min-width: 800px) 800px, 100vw"·     srcset="…640w, …750w, …800w"&gt;``
```

Three variants instead of one. This matters the first time a real photo goes into a post — at 4000px wide the difference is megabytes on mobile.

## npm audit in CI

The workflow ran type checks and the build but never `npm audit`, so a vulnerable dependency could sit in the tree indefinitely — especially in a fork whose owner ignores Dependabot. Now fails on high/critical. Currently passes with zero findings.

## Considered and rejected

**`Cross-Origin-Resource-Policy`.** `same-origin` is the safe-looking default, but share cards under `/og/` exist to be fetched by other origins. The benefit doesn't justify quietly breaking link previews.

## Measured baseline (unchanged by this PR)

First load of a post page, gzipped:

| Asset | gzip |
|---|---|
| CSS | 7.4 KB |
| ClientRouter (view transitions) | 4.7 KB |
| HTML | 4.7 KB |
| favicon + page shim | 0.3 KB |
| **Total** | **≈ 17 KB** |

## Verification

- `npm audit --audit-level=high` → passes
- `astro check` → 0 errors, 0 warnings, 0 hints
- contrast → 10 blocks pass AA
- build → 4 pages, headers generated

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdVW1vzqY2nWsiNqWxpZQV)_