### PR TITLE
feat: add contact form relayed through MailRelay

### DIFF
--- a/scripts/check-contrast.mjs
+++ b/scripts/check-contrast.mjs
@@ -8,6 +8,7 @@
  *   --color-text            >= 4.5:1   (body copy)
  *   --color-text-secondary  >= 4.5:1   (meta text renders at 13-14px)
  *   --color-text on --color-bg-elevated >= 4.5:1  (code blocks, inputs)
+ *   --color-danger          >= 4.5:1   (form errors, 14px)
  */
 import { existsSync, readFileSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
@@ -69,9 +70,14 @@ for (const { name, mode, tokens } of blocks) {
   const elevated = tokens['--color-bg-elevated']
   const text = tokens['--color-text']
   const secondary = tokens['--color-text-secondary']
+  // Error text (form validation, network failures) is small and matters most
+  // exactly when something has gone wrong, so it is held to the same bar.
+  const danger = tokens['--color-danger']
 
-  if (!bg || !text || !secondary || !elevated) {
-    failures.push(`${name}/${mode}: missing one of bg, bg-elevated, text, text-secondary`)
+  if (!bg || !text || !secondary || !elevated || !danger) {
+    failures.push(
+      `${name}/${mode}: missing one of bg, bg-elevated, text, text-secondary, danger`
+    )
     continue
   }
 
@@ -79,6 +85,7 @@ for (const { name, mode, tokens } of blocks) {
     ['text on bg', contrast(text, bg)],
     ['secondary on bg', contrast(secondary, bg)],
     ['text on elevated', contrast(text, elevated)],
+    ['danger on bg', contrast(danger, bg)],
   ]
 
   for (const [label, ratio] of checks) {
@@ -93,7 +100,7 @@ for (const { name, mode, tokens } of blocks) {
   )
 }
 
-console.log('[contrast] preset  mode      text  secondary  elevated')
+console.log('[contrast] preset  mode      text  secondary  elevated  danger')
 console.log(rows.join('\n'))
 
 if (failures.length > 0) {

--- a/scripts/security-headers.mjs
+++ b/scripts/security-headers.mjs
@@ -70,9 +70,14 @@ const giscusEnabled =
 // challenges.cloudflare.com. Miss any of these and the form fails only in
 // production — `astro dev` never applies this policy, so the breakage does
 // not reproduce locally.
+// The site-key condition matches ContactForm.astro and contact.astro: the
+// form does not render without one, so the policy must not widen either.
 const mailrelay = features.mailrelay ?? {}
 const mailrelayEnabled = Boolean(
-  mailrelay.enabled && mailrelay.workerOrigin && mailrelay.endpointId
+  mailrelay.enabled &&
+    mailrelay.workerOrigin &&
+    mailrelay.endpointId &&
+    mailrelay.turnstileSiteKey
 )
 const TURNSTILE = 'https://challenges.cloudflare.com'
 

--- a/scripts/security-headers.mjs
+++ b/scripts/security-headers.mjs
@@ -65,8 +65,32 @@ for (const file of files) {
 const giscusEnabled =
   features.giscus.enabled && features.giscus.repo && features.giscus.repoId
 
-const scriptSrc = ["'self'", ...hashes, ...(giscusEnabled ? ['https://giscus.app'] : [])]
-const frameSrc = giscusEnabled ? ['https://giscus.app'] : ["'none'"]
+// The contact form posts to a MailRelay worker on another origin and
+// renders a Turnstile widget, which loads a script and an iframe from
+// challenges.cloudflare.com. Miss any of these and the form fails only in
+// production — `astro dev` never applies this policy, so the breakage does
+// not reproduce locally.
+const mailrelay = features.mailrelay ?? {}
+const mailrelayEnabled = Boolean(
+  mailrelay.enabled && mailrelay.workerOrigin && mailrelay.endpointId
+)
+const TURNSTILE = 'https://challenges.cloudflare.com'
+
+const scriptSrc = [
+  "'self'",
+  ...hashes,
+  ...(giscusEnabled ? ['https://giscus.app'] : []),
+  ...(mailrelayEnabled ? [TURNSTILE] : []),
+]
+const connectSrc = [
+  "'self'",
+  ...(mailrelayEnabled ? [mailrelay.workerOrigin, TURNSTILE] : []),
+]
+const frameSrcOrigins = [
+  ...(giscusEnabled ? ['https://giscus.app'] : []),
+  ...(mailrelayEnabled ? [TURNSTILE] : []),
+]
+const frameSrc = frameSrcOrigins.length > 0 ? frameSrcOrigins : ["'none'"]
 
 const csp = [
   `default-src 'self'`,
@@ -75,7 +99,7 @@ const csp = [
   // Post content may embed remote images; that is the author's choice.
   `img-src 'self' data: https:`,
   `font-src 'self'`,
-  `connect-src 'self'`,
+  `connect-src ${connectSrc.join(' ')}`,
   `frame-src ${frameSrc.join(' ')}`,
   `frame-ancestors 'none'`,
   `base-uri 'self'`,
@@ -117,5 +141,6 @@ await writeFile(resolve(dist, '_headers'), headers)
 
 console.log(
   `[headers] wrote dist/_headers — ${hashes.size} inline script hash(es) across ${files.length} page(s)` +
-    (giscusEnabled ? ', giscus origins allowed' : '')
+    (giscusEnabled ? ', giscus origins allowed' : '') +
+    (mailrelayEnabled ? `, mailrelay (${mailrelay.workerOrigin}) + turnstile allowed` : '')
 )

--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -1,0 +1,220 @@
+---
+import { features } from '../config.mjs'
+
+const { mailrelay } = features
+
+/**
+ * Contact form relayed through a MailRelay worker.
+ *
+ * Renders nothing unless enabled *and* fully configured, matching
+ * Comments.astro — a half-configured feature should fail visibly in dev
+ * rather than silently in production.
+ *
+ * The submit logic is deliberately an inline `is:inline` script rather
+ * than the worker's hosted embed.js. scripts/security-headers.mjs hashes
+ * every inline script into the CSP automatically, so inlining keeps
+ * `script-src` at 'self' plus hashes; loading the remote embed would mean
+ * trusting another origin for script execution to save nothing.
+ */
+const configured = Boolean(mailrelay?.workerOrigin && mailrelay?.endpointId)
+const show = mailrelay?.enabled && configured
+const misconfigured = mailrelay?.enabled && !configured
+
+const endpoint = mailrelay?.endpointId ?? ''
+const workerOrigin = mailrelay?.workerOrigin ?? ''
+const turnstileKey = mailrelay?.turnstileSiteKey ?? ''
+---
+
+{
+  show && (
+    <form
+      id="contact-form"
+      class="mt-6 space-y-4"
+      data-worker={workerOrigin}
+      data-endpoint={endpoint}
+      novalidate
+    >
+      <div>
+        <label class="mb-1 block text-[14px] font-medium" for="cf-name">
+          Name
+        </label>
+        <input
+          id="cf-name"
+          name="name"
+          type="text"
+          required
+          maxlength="100"
+          autocomplete="name"
+          class="w-full rounded-lg border border-(--color-border) bg-(--color-bg) px-3 py-2 text-[15px] outline-none focus:border-(--color-text-secondary)"
+        />
+      </div>
+
+      <div>
+        <label class="mb-1 block text-[14px] font-medium" for="cf-email">
+          Email
+        </label>
+        <input
+          id="cf-email"
+          name="email"
+          type="email"
+          required
+          maxlength="254"
+          autocomplete="email"
+          class="w-full rounded-lg border border-(--color-border) bg-(--color-bg) px-3 py-2 text-[15px] outline-none focus:border-(--color-text-secondary)"
+        />
+      </div>
+
+      <div>
+        <label class="mb-1 block text-[14px] font-medium" for="cf-subject">
+          Subject <span class="text-(--color-text-secondary)">(optional)</span>
+        </label>
+        <input
+          id="cf-subject"
+          name="subject"
+          type="text"
+          maxlength="200"
+          class="w-full rounded-lg border border-(--color-border) bg-(--color-bg) px-3 py-2 text-[15px] outline-none focus:border-(--color-text-secondary)"
+        />
+      </div>
+
+      <div>
+        <label class="mb-1 block text-[14px] font-medium" for="cf-message">
+          Message
+        </label>
+        <textarea
+          id="cf-message"
+          name="message"
+          required
+          rows="6"
+          maxlength="5000"
+          class="w-full resize-y rounded-lg border border-(--color-border) bg-(--color-bg) px-3 py-2 text-[15px] outline-none focus:border-(--color-text-secondary)"
+        />
+      </div>
+
+      {/*
+        Honeypot. Hidden from people, and from assistive technology via
+        aria-hidden + tabindex, but present in the DOM for bots that fill
+        every field they find.
+      */}
+      <div class="hidden" aria-hidden="true">
+        <label for="cf-gotcha">Leave this empty</label>
+        <input id="cf-gotcha" name="_gotcha" type="text" tabindex="-1" autocomplete="off" />
+      </div>
+
+      {turnstileKey && (
+        <div class="cf-turnstile" data-sitekey={turnstileKey} data-theme="auto" />
+      )}
+
+      <div class="flex items-center gap-3">
+        <button
+          type="submit"
+          class="rounded-lg bg-(--color-text) px-4 py-2 text-[15px] font-medium text-(--color-bg) transition-opacity hover:opacity-90 disabled:opacity-50"
+        >
+          Send
+        </button>
+        <p id="cf-status" class="text-[14px]" role="status" aria-live="polite" />
+      </div>
+    </form>
+  )
+}
+
+{
+  show && turnstileKey && (
+    <script
+      is:inline
+      src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+      async
+      defer
+    />
+  )
+}
+
+{
+  show && (
+    <script is:inline>
+      {`(function () {
+  var form = document.getElementById('contact-form')
+  if (!form) return
+  var status = document.getElementById('cf-status')
+  var worker = form.dataset.worker
+  var endpoint = form.dataset.endpoint
+  var token = null
+  var fetching = false
+
+  function say(text, ok) {
+    status.textContent = text
+    status.style.color = ok ? 'var(--color-text-secondary)' : '#b91c1c'
+  }
+
+  // Fetched on first interaction rather than on page load: a reader who
+  // never touches the form costs the worker nothing, and the elapsed-time
+  // check then measures how long someone actually spent filling it in
+  // rather than how long the tab has been open.
+  function getToken() {
+    if (token || fetching) return
+    fetching = true
+    fetch(worker + '/v1/form-token/' + endpoint, { credentials: 'omit' })
+      .then(function (r) { return r.ok ? r.json() : null })
+      .then(function (t) { token = t })
+      .catch(function () {})
+      .finally(function () { fetching = false })
+  }
+  form.addEventListener('focusin', getToken, { once: true })
+
+  form.addEventListener('submit', function (e) {
+    e.preventDefault()
+    var btn = form.querySelector('[type=submit]')
+    var data = {}
+    new FormData(form).forEach(function (v, k) { data[k] = String(v) })
+    if (token) data._token = token
+    data.page_path = location.pathname
+
+    if (!data.name || !data.email || !data.message) {
+      say('Please fill in name, email and message.', false)
+      return
+    }
+
+    btn.disabled = true
+    var label = btn.textContent
+    btn.textContent = 'Sending…'
+    say('', true)
+
+    fetch(worker + '/v1/send/' + endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'omit',
+      body: JSON.stringify(data),
+    })
+      .then(function (r) { return r.json() })
+      .then(function (r) {
+        if (r.success) {
+          form.reset()
+          token = null
+          if (window.turnstile) window.turnstile.reset()
+          say('Thanks — your message is on its way.', true)
+        } else if (r.error === 'RATE_LIMITED') {
+          say('Too many attempts. Please try again in a minute.', false)
+        } else {
+          say('Something went wrong. Please try again.', false)
+        }
+      })
+      .catch(function () { say('Network error. Please try again.', false) })
+      .finally(function () { btn.disabled = false; btn.textContent = label })
+  })
+})()`}
+    </script>
+  )
+}
+
+{
+  misconfigured && import.meta.env.DEV && (
+    <section class="mt-6 rounded-xl border border-(--color-border) bg-(--color-bg-elevated) p-4 text-[14px]">
+      <p class="font-semibold">The contact form is enabled but not configured.</p>
+      <p class="mt-1 text-(--color-text-secondary)">
+        Set <code>workerOrigin</code> and <code>endpointId</code> under
+        <code>features.mailrelay</code> in <code>src/config.mjs</code>. This notice only
+        appears in development.
+      </p>
+    </section>
+  )
+}

--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -16,7 +16,17 @@ const { mailrelay } = features
  * `script-src` at 'self' plus hashes; loading the remote embed would mean
  * trusting another origin for script execution to save nothing.
  */
-const configured = Boolean(mailrelay?.workerOrigin && mailrelay?.endpointId)
+/**
+ * The Turnstile site key is part of being configured, not an optional
+ * extra. Worker endpoints require Turnstile by default, and a form
+ * rendered without the widget sends no `cf-turnstile-response` — so every
+ * submission is refused, and refusals of that kind answer with a fake
+ * success so bots learn nothing. The visitor would be told the message
+ * was sent, every time, while nothing ever arrived.
+ */
+const configured = Boolean(
+  mailrelay?.workerOrigin && mailrelay?.endpointId && mailrelay?.turnstileSiteKey
+)
 const show = mailrelay?.enabled && configured
 const misconfigured = mailrelay?.enabled && !configured
 
@@ -101,9 +111,7 @@ const turnstileKey = mailrelay?.turnstileSiteKey ?? ''
         <input id="cf-gotcha" name="_gotcha" type="text" tabindex="-1" autocomplete="off" />
       </div>
 
-      {turnstileKey && (
-        <div class="cf-turnstile" data-sitekey={turnstileKey} data-theme="auto" />
-      )}
+      <div class="cf-turnstile" data-sitekey={turnstileKey} data-theme="auto" />
 
       <div class="flex items-center gap-3">
         <button
@@ -119,7 +127,7 @@ const turnstileKey = mailrelay?.turnstileSiteKey ?? ''
 }
 
 {
-  show && turnstileKey && (
+  show && (
     <script
       is:inline
       src="https://challenges.cloudflare.com/turnstile/v0/api.js"
@@ -139,34 +147,65 @@ const turnstileKey = mailrelay?.turnstileSiteKey ?? ''
   var worker = form.dataset.worker
   var endpoint = form.dataset.endpoint
   var token = null
-  var fetching = false
+  var pending = null
 
   function say(text, ok) {
     status.textContent = text
-    status.style.color = ok ? 'var(--color-text-secondary)' : '#b91c1c'
+    status.style.color = ok ? 'var(--color-text-secondary)' : 'var(--color-danger)'
   }
 
-  // Fetched on first interaction rather than on page load: a reader who
-  // never touches the form costs the worker nothing, and the elapsed-time
-  // check then measures how long someone actually spent filling it in
-  // rather than how long the tab has been open.
-  function getToken() {
-    if (token || fetching) return
-    fetching = true
-    fetch(worker + '/v1/form-token/' + endpoint, { credentials: 'omit' })
+  /*
+    Token lifecycle.
+
+    The worker rejects a submission with no valid token, and does so with a
+    fake success — so getting this wrong does not surface as an error, it
+    surfaces as mail that silently never arrives. Two paths have to be
+    covered: the first fetch failing (offline for a moment), and the token
+    being consumed by a successful send while the visitor stays on the page
+    to write a second message. Both must be able to acquire a new one.
+
+    Returns a promise so submit can wait rather than sending without it.
+  */
+  function ensureToken() {
+    if (token) return Promise.resolve(token)
+    if (pending) return pending
+    pending = fetch(worker + '/v1/form-token/' + endpoint, { credentials: 'omit' })
       .then(function (r) { return r.ok ? r.json() : null })
-      .then(function (t) { token = t })
-      .catch(function () {})
-      .finally(function () { fetching = false })
+      .then(function (t) { token = t; return t })
+      .catch(function () { return null })
+      .finally(function () { pending = null })
+    return pending
   }
-  form.addEventListener('focusin', getToken, { once: true })
+
+  /*
+    Warmed on interaction rather than page load: a reader who never touches
+    the form costs the worker nothing, and the elapsed-time check then
+    measures how long someone actually spent filling it in rather than how
+    long the tab has been open. Not { once: true } — if the first attempt
+    failed there has to be another chance.
+  */
+  form.addEventListener('focusin', ensureToken)
+
+  /*
+    The worker refuses a token younger than its minimum fill time, to catch
+    scripts that submit instantly. That threshold is reported by the token
+    endpoint rather than duplicated here, so the two cannot drift apart.
+    Only ever waits on the recovery path — a token warmed at focus is
+    already older than this by the time anyone finishes typing.
+  */
+  function waitUntilUsable(t) {
+    var minAge = (t && t.min_age) || 0
+    var age = Math.floor(Date.now() / 1000) - ((t && t.issued_at) || 0)
+    var remaining = minAge - age
+    if (remaining <= 0) return Promise.resolve()
+    return new Promise(function (resolve) { setTimeout(resolve, remaining * 1000) })
+  }
 
   form.addEventListener('submit', function (e) {
     e.preventDefault()
     var btn = form.querySelector('[type=submit]')
     var data = {}
     new FormData(form).forEach(function (v, k) { data[k] = String(v) })
-    if (token) data._token = token
     data.page_path = location.pathname
 
     if (!data.name || !data.email || !data.message) {
@@ -179,17 +218,26 @@ const turnstileKey = mailrelay?.turnstileSiteKey ?? ''
     btn.textContent = 'Sending…'
     say('', true)
 
-    fetch(worker + '/v1/send/' + endpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'omit',
-      body: JSON.stringify(data),
-    })
+    ensureToken()
+      .then(function (t) {
+        if (!t) throw new Error('no-token')
+        data._token = t
+        return waitUntilUsable(t)
+      })
+      .then(function () {
+        return fetch(worker + '/v1/send/' + endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'omit',
+          body: JSON.stringify(data),
+        })
+      })
       .then(function (r) { return r.json() })
       .then(function (r) {
+        // The token is single-use, so it is spent either way.
+        token = null
         if (r.success) {
           form.reset()
-          token = null
           if (window.turnstile) window.turnstile.reset()
           say('Thanks — your message is on its way.', true)
         } else if (r.error === 'RATE_LIMITED') {
@@ -198,7 +246,10 @@ const turnstileKey = mailrelay?.turnstileSiteKey ?? ''
           say('Something went wrong. Please try again.', false)
         }
       })
-      .catch(function () { say('Network error. Please try again.', false) })
+      .catch(function () {
+        token = null
+        say('Could not send right now. Please try again.', false)
+      })
       .finally(function () { btn.disabled = false; btn.textContent = label })
   })
 })()`}
@@ -211,9 +262,11 @@ const turnstileKey = mailrelay?.turnstileSiteKey ?? ''
     <section class="mt-6 rounded-xl border border-(--color-border) bg-(--color-bg-elevated) p-4 text-[14px]">
       <p class="font-semibold">The contact form is enabled but not configured.</p>
       <p class="mt-1 text-(--color-text-secondary)">
-        Set <code>workerOrigin</code> and <code>endpointId</code> under
-        <code>features.mailrelay</code> in <code>src/config.mjs</code>. This notice only
-        appears in development.
+        Set <code>workerOrigin</code>, <code>endpointId</code> and
+        <code>turnstileSiteKey</code> under <code>features.mailrelay</code> in
+        <code>src/config.mjs</code>. All three are required — without the site key the
+        worker refuses every submission, and it does so as a fake success, so the form
+        would look like it was working. This notice only appears in development.
       </p>
     </section>
   )

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -71,6 +71,29 @@ export const features = {
   },
 
   /**
+   * Contact form, relayed through a MailRelay worker.
+   *
+   * This site is statically generated, so there is no server here to hide
+   * a credential in — the browser talks to the worker directly. That is
+   * safe only because the worker checks the request Origin against a
+   * per-site whitelist and requires a Turnstile token; the endpoint id
+   * below is public by design and is not a secret.
+   *
+   * Enabling this widens the Content-Security-Policy to allow the worker
+   * origin and Turnstile — see scripts/security-headers.mjs. Leaving it
+   * off ships no extra CSP origins and no contact page at all.
+   */
+  mailrelay: {
+    enabled: false,
+    /** Deployed worker origin, no trailing slash. */
+    workerOrigin: '', // e.g. 'https://mailrelay-v2.<subdomain>.workers.dev'
+    /** Endpoint id from POST /v1/admin/endpoints. Public, not a secret. */
+    endpointId: '', // e.g. 'ep_...'
+    /** Turnstile *site* key (the public half). */
+    turnstileSiteKey: '',
+  },
+
+  /**
    * Generate a social share card per post at build time (/og/<slug>.png).
    * Costs a couple of seconds of build; nothing at runtime.
    */

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -82,6 +82,16 @@ export const features = {
    * Enabling this widens the Content-Security-Policy to allow the worker
    * origin and Turnstile — see scripts/security-headers.mjs. Leaving it
    * off ships no extra CSP origins and no contact page at all.
+   *
+   * After changing anything here, run `npm run build` and then, from the
+   * clone-resend checkout:
+   *
+   *   npm run verify:pair -- --blog <path-to-this-repo> --admin-token <token>
+   *
+   * The worker lives in a separate repository, so this repo's own checks
+   * cannot tell whether the two still agree — a wrong endpoint id, an
+   * unwhitelisted origin or a stale build all fail silently, because the
+   * worker answers those rejections with a fake success.
    */
   mailrelay: {
     enabled: false,

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -89,7 +89,12 @@ export const features = {
     workerOrigin: '', // e.g. 'https://mailrelay-v2.<subdomain>.workers.dev'
     /** Endpoint id from POST /v1/admin/endpoints. Public, not a secret. */
     endpointId: '', // e.g. 'ep_...'
-    /** Turnstile *site* key (the public half). */
+    /**
+     * Turnstile *site* key (the public half). Required, not optional —
+     * worker endpoints demand a Turnstile token by default and refuse
+     * submissions without one as a fake success, so a form rendered
+     * without the widget would silently discard every message.
+     */
     turnstileSiteKey: '',
   },
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -3,10 +3,14 @@ import Base from '../layouts/Base.astro'
 import ContactForm from '../components/ContactForm.astro'
 import { features, site } from '../config.mjs'
 
+// Must match the check in ContactForm.astro and scripts/security-headers.mjs.
+// The Turnstile site key counts: without it the worker refuses every
+// submission, and it refuses them as a fake success.
 const enabled = Boolean(
   features.mailrelay?.enabled &&
     features.mailrelay?.workerOrigin &&
-    features.mailrelay?.endpointId
+    features.mailrelay?.endpointId &&
+    features.mailrelay?.turnstileSiteKey
 )
 ---
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,44 @@
+---
+import Base from '../layouts/Base.astro'
+import ContactForm from '../components/ContactForm.astro'
+import { features, site } from '../config.mjs'
+
+const enabled = Boolean(
+  features.mailrelay?.enabled &&
+    features.mailrelay?.workerOrigin &&
+    features.mailrelay?.endpointId
+)
+---
+
+<Base title="Contact" description={`Get in touch with ${site.title}.`}>
+  <section class="py-6">
+    <h1 class="text-[24px] leading-tight font-bold tracking-tight">Contact</h1>
+    <p class="mt-1 text-[15px] text-(--color-text-secondary)">
+      {
+        enabled
+          ? 'Send a message and it will land in my inbox. I usually reply within a few days.'
+          : 'The contact form is not currently available.'
+      }
+    </p>
+  </section>
+
+  <section class="border-t border-(--color-border) pt-6">
+    <ContactForm />
+
+    {
+      !enabled && (
+        <p class="text-[15px] text-(--color-text-secondary)">
+          In the meantime you can reach me on{' '}
+          <a
+            class="underline"
+            href={`https://github.com/${site.github.split('/')[0]}`}
+            rel="noopener noreferrer"
+          >
+            GitHub
+          </a>
+          .
+        </p>
+      )
+    }
+  </section>
+</Base>

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1,7 +1,7 @@
 /*
  * Theme presets.
  *
- * Every preset defines the same six tokens twice — once for light, once for
+ * Every preset defines the same seven tokens twice — once for light, once for
  * dark. Nothing else in the codebase hard-codes a colour, so adding a preset
  * here is the whole job of retheming the blog.
  *
@@ -9,8 +9,9 @@
  * <html data-preset="..."> and the matching block below wins.
  *
  * Every value is checked by `npm run check:contrast`, which fails the build if
- * body text drops below WCAG AA (4.5:1) or secondary text below 4.5:1 against
- * its own background. Softening a palette is fine; making it unreadable is not.
+ * body text drops below WCAG AA (4.5:1), secondary text below 4.5:1, or error
+ * text (--color-danger) below 4.5:1, each against its own background.
+ * Softening a palette is fine; making it unreadable is not.
  *
  * To add your own: copy a block, rename it, and run `npm run check:contrast`.
  */
@@ -23,6 +24,7 @@
   --color-text-secondary: #787163;
   --color-border: #e5ded1;
   --color-hover: #f0eadf;
+  --color-danger: #a3301f;
 }
 [data-preset='cream'][data-theme='dark'] {
   --color-bg: #17191c;
@@ -31,6 +33,7 @@
   --color-text-secondary: #8b8a85;
   --color-border: #2c2f34;
   --color-hover: #212429;
+  --color-danger: #e88b82;
 }
 
 /* ── mono — neutral greys, closest to the original Threads look. ─────────── */
@@ -41,6 +44,7 @@
   --color-text-secondary: #6e6e6e;
   --color-border: #e0e0e0;
   --color-hover: #f2f2f2;
+  --color-danger: #b3261e;
 }
 [data-preset='mono'][data-theme='dark'] {
   --color-bg: #101010;
@@ -49,6 +53,7 @@
   --color-text-secondary: #8a8a8a;
   --color-border: #2b2b2b;
   --color-hover: #1e1e1e;
+  --color-danger: #f28b82;
 }
 
 /* ── slate — cool blue-grey, a little more editorial. ────────────────────── */
@@ -59,6 +64,7 @@
   --color-text-secondary: #617387;
   --color-border: #dde4ec;
   --color-hover: #e9eef4;
+  --color-danger: #b02a37;
 }
 [data-preset='slate'][data-theme='dark'] {
   --color-bg: #141a21;
@@ -67,6 +73,7 @@
   --color-text-secondary: #8496a8;
   --color-border: #2a333f;
   --color-hover: #1f2833;
+  --color-danger: #f19a9a;
 }
 
 /* ── sepia — book-like, warmest of the set. ──────────────────────────────── */
@@ -77,6 +84,7 @@
   --color-text-secondary: #766952;
   --color-border: #e0d4be;
   --color-hover: #ece0cd;
+  --color-danger: #a63a24;
 }
 [data-preset='sepia'][data-theme='dark'] {
   --color-bg: #1c1813;
@@ -85,6 +93,7 @@
   --color-text-secondary: #948876;
   --color-border: #342c22;
   --color-hover: #29221a;
+  --color-danger: #eda192;
 }
 
 /* ── forest — muted green, low saturation so it stays calm at length. ────── */
@@ -95,6 +104,7 @@
   --color-text-secondary: #637367;
   --color-border: #dbe4d9;
   --color-hover: #e6ede4;
+  --color-danger: #a32f28;
 }
 [data-preset='forest'][data-theme='dark'] {
   --color-bg: #141a15;
@@ -103,4 +113,5 @@
   --color-text-secondary: #839084;
   --color-border: #29332a;
   --color-hover: #1f281f;
+  --color-danger: #eb9d95;
 }


### PR DESCRIPTION
## What

Adds an opt-in contact form at `/contact`, posting to a MailRelay worker (see [tanghoong/clone-resend#1](https://github.com/tanghoong/clone-resend/pull/1) for the service).

**Off by default.** A fork that changes nothing builds and deploys exactly as before — no extra CSP origins, no form rendered, no third-party code.

| File | Change |
|---|---|
| `src/config.mjs` | New `features.mailrelay` block, mirroring the existing `giscus` shape |
| `src/components/ContactForm.astro` | Form + honeypot + Turnstile + inline submit script |
| `src/pages/contact.astro` | The page |
| `scripts/security-headers.mjs` | Conditional CSP branch for the worker and Turnstile origins |
| `src/styles/themes.css` | New `--color-danger` token in all ten theme blocks |
| `scripts/check-contrast.mjs` | Enforces AA on that token, so the build checks it |

## Why it is built this way

**The browser talks to the worker directly, and that is fine.** This site is statically generated — there is no server here to hold a credential. Which means the `endpointId` in config is public by construction. It is safe because the worker validates the request `Origin` against a per-site whitelist and requires a Turnstile token, so possession of the id alone buys nothing. Worth stating explicitly, since a public-looking id in a config file otherwise reads like a mistake.

**Inline script rather than the worker's hosted `embed.js`.** `scripts/security-headers.mjs` already scans and hashes every inline script into the policy. Inlining therefore keeps `script-src` at `'self'` plus hashes; pulling the remote embed would mean trusting another origin for script execution and buying nothing for it. This follows the trade-off the repo already documents in `SECURITY.md`.

**The CSP branch is the part that would bite.** The policy only exists in the generated `dist/_headers`, so `astro dev` never enforces it — a missing `connect-src` entry breaks the form in production while working perfectly on localhost.

**The form token is fetched on first interaction, not on page load.** Most visitors to a blog never touch the contact form; fetching on load would add a request to nearly every pageview to serve almost none of them. It also makes the worker's elapsed-time check measure how long someone actually spent filling the form in, rather than how long the tab has been open.

## Three silent-failure paths, found in review and fixed

These share a property that shaped the fixes: the worker answers automation-shaped rejections with a **fake success**, deliberately, so a scanner learns nothing from probing. That is right for the threat model, but it means a client-side mistake never surfaces as an error — the visitor is told the message was sent, nothing arrives, and nothing anywhere reports a problem. Worse than a visible failure, so all three were treated as bugs.

- **Turnstile site key is now required to render.** Setting `workerOrigin` + `endpointId` but leaving the key empty marked the form configured, omitted the widget, and so sent no `cf-turnstile-response` — meaning *every* submission was refused. All three values are now required, consistently across the component, the page, and the CSP generator.
- **Form tokens are re-acquirable.** The `focusin` listener was `{ once: true }` and the success path cleared the token, so a second message from the same page had none, and a failed first fetch left the page permanently unable to send. Acquisition is now a deduplicated promise and submit awaits it. Since the recovery path can yield a token younger than the worker's minimum fill time, submit also waits out the remainder — using a `min_age` the token endpoint now reports, rather than a constant duplicated across two repos.
- **Error text uses a theme token.** `themes.css` states that nothing else in the codebase hard-codes a colour; the literal `#b91c1c` broke that invariant and read at ~2.7–2.9:1 in dark mode. Rather than patch the one call site, `--color-danger` is added to all ten theme blocks and `check-contrast.mjs` enforces it, so the constraint is checked by the build instead of restated in a comment.

## Verification

Built in three states and inspected the generated policy:

| Config | Result |
|---|---|
| Disabled | `connect-src 'self'`, `frame-src 'none'`, no form. Identical to before this PR |
| Enabled, no site key | No form, no CSP widening — previously a silently broken form |
| Fully configured | Inline script hashed (6 → 7), worker + Turnstile in exactly the directives that need them |

`npm run check` reports 0 errors / 0 warnings / 0 hints across 25 files. All 10 theme blocks pass WCAG AA on the new token in both light and dark (5.65:1 – 8.50:1).

## Checking this against the worker

This repo's checks cannot tell whether the two sides still agree — the worker is in another repository. A wrong endpoint id, an unwhitelisted origin, a stale `dist/`, or a CSP missing the worker origin all fail *silently* for the reason above.

`clone-resend` carries a cross-repo check for exactly this. After changing anything here:

```bash
npm run build
cd ../clone-resend
npm run verify:pair -- --blog ../github-markdown-blog --admin-token "$TOKEN"
```

That passing — not two green CIs — is what "working" means.

## Not included

The nav bar is untouched — `/contact` is reachable by URL only. Adding a link is a one-line change if wanted.