### PR TITLE
chore(deps-dev): bump typescript to 6.0.3 (supersedes #33)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.10",
         "pagefind": "^1.3.0",
-        "typescript": "^5.7.2"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@astrojs/check": {
@@ -7005,9 +7005,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.10",
     "pagefind": "^1.3.0",
-    "typescript": "^5.7.2"
+    "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
## Summary

Supersedes #33. You asked me to test whether TypeScript 7 holds — it doesn't, and the reason is upstream, not in our code.

## Why #33 cannot be merged

It doesn't install. `@astrojs/check@0.9.10` declares:

```
peer typescript@"^5.0.0 || ^6.0.0"
```

So `npm ci` fails with `ERESOLVE` **before CI reaches the type check**:

```
Could not resolve dependency:
peer typescript@"^5.0.0 || ^6.0.0" from @astrojs/check@0.9.10
Conflicting peer dependency: typescript@6.0.3
```

This isn't something we can work around sensibly — TypeScript 7 is unavailable here until `@astrojs/check` publishes support for it. Worth noting that a green tick on #33 would have been meaningless: the failure is at install, so nothing downstream ever ran.

## What this PR does instead

TypeScript 6 is the highest version that peer range allows, and npm's own error names it. It's clean:

| Check | Result |
|---|---|
| `npm ci` | installs |
| `astro check` | 0 errors, 0 warnings, 0 hints |
| `npm run check:contrast` | 10 theme blocks pass AA |
| `npm audit --audit-level=high` | passes |
| `npm run build` | 5 pages, headers generated |

The 5 pages include the `/contact` route from #31, so this is verified against the current tree rather than a stale one.

## Method

Cut from current `main` (`2601ece`) with a fresh `npm ci`, not by patching the Dependabot branch in place — that would have taken the branch out of Dependabot's management for no benefit.

## Suggested handling of #33

Close it, and if the churn is annoying:

```
·@·d·ependabot i·gnore t·his major version
```

Dependabot will re-propose TypeScript 7 once `@astrojs/check` widens its peer range, which is the right moment to take it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdVW1vzqY2nWsiNqWxpZQV)_