### PR TITLE
feat(contents): add two engineering posts on production AI systems

### DIFF
--- a/contents/engineering/an-ai-agent-does-not-need-to-remember-everything.md
+++ b/contents/engineering/an-ai-agent-does-not-need-to-remember-everything.md
@@ -1,0 +1,112 @@
+---
+title: An AI agent does not need to remember everything
+date: 2026-08-01
+tags: [AI Agents, Enterprise AI, System Architecture, AI Engineering]
+excerpt: Producing a convincing answer is no longer the hard part. The hard part is the agent still working tomorrow — and that turns out to be a state problem, not a memory problem.
+---
+
+Getting an AI agent to produce a convincing answer is no longer the hardest problem. Models are good enough that a carefully written prompt and two or three tools will get you something that demos well.
+
+The real test begins the day after. The agent has to keep operating across longer conversations, failed tools, changing business rules, human handovers, and workflows that were interrupted halfway through. That is a different engineering problem, and most of its difficulty has nothing to do with the model.
+
+From building enterprise workflows and AI customer-support systems, I have become increasingly convinced of one thing:
+
+> An AI agent does not need to remember everything. It needs to preserve what matters.
+
+The instinct when a conversation gets complicated is to carry more of it forward — append the last tool output, re-inject the policy document, keep the full transcript in the window. It feels like diligence. In practice it is the fastest way to build a system that is expensive to run, impossible to inspect, and unpredictable in exactly the situations where you need it to be predictable.
+
+## Four things that are not the same
+
+Most of the confusion in agent design comes from treating these as one thing:
+
+| | What it holds | Shape | Read by |
+|---|---|---|---|
+| **Conversation history** | the literal turns, verbatim | append-only, unbounded | the model, when relevant |
+| **Memory** | durable facts that outlive this conversation | small, curated, mutable | the model, selectively |
+| **Workflow state** | where this task is right now | bounded, mutable, structured | the orchestrator |
+| **Audit log** | what happened and why | append-only, immutable | humans, compliance |
+
+Conversation history is not memory. A transcript is raw material; memory is what you decided was worth keeping. By turn forty, most of a transcript is noise — clarifications, retries, the model apologising for a tool that timed out.
+
+Memory is not workflow state. That a customer prefers email over phone is memory. That their refund is at step three of five, blocked on a manager approval, is workflow state. The first is a fact about a person. The second is a position in a process, and it is the thing you resume from.
+
+Workflow state is not an audit log. State tells you where you are; the log tells you how you got there. State is overwritten as the task advances. The log never is — which is precisely why it can answer the question a regulator or an angry customer actually asks.
+
+Collapse these into one large context window and you lose the properties that made each of them useful.
+
+## What operational state actually holds
+
+Instead of repeatedly carrying the whole conversation forward, I prefer to maintain a structured operational state that answers a fixed set of questions:
+
+- What is the user trying to achieve?
+- What has already been completed?
+- What evidence has been collected?
+- Which decisions and policy rules were applied?
+- What failed, and what has already been retried?
+- What is still unresolved?
+- Does the next step require human approval?
+- What should happen next?
+
+Written down, that is a small object — a few hundred tokens, not a few hundred thousand:
+
+```ts
+interface TaskState {
+  goal: string
+  completed: Step[]
+  pending: Step[]
+  evidence: EvidenceRef[]        // pointers, not payloads
+  decisions: { rule: string; outcome: string; at: string }[]
+  failures: { step: string; error: string; attempts: number }[]
+  blockedOn: 'human_approval' | 'external_system' | null
+  nextAction: Action | null
+}
+```
+
+The detail worth emphasising is `evidence`. The original messages, documents, and tool outputs do not go into the state object — references to them do. The raw material stays in storage as evidence and is retrieved only when a step actually needs it. A refund decision does not need the full order history in context; it needs the order total, the purchase date, and the policy clause that applied.
+
+This is what makes the difference between an agent that degrades over a long conversation and one that does not. State that answers eight questions stays roughly the same size at turn five and turn five hundred. A transcript does not.
+
+## Why one big context window fails
+
+Three ways, and they compound:
+
+**It gets expensive.** Cost scales with what you carry, and carrying everything means paying for the whole history on every single turn — including the ninety per cent of it that has no bearing on the next decision.
+
+**It gets hard to inspect.** When something goes wrong, "read the transcript" is not a debugging strategy. With explicit state you can look at one object and see the goal, the completed steps, and the failure. With a context window you are reconstructing intent from a wall of text.
+
+**It gets unpredictable.** Long contexts dilute attention. A policy rule stated at turn three competes with forty turns of chatter by the time it matters. The model does not forget it exactly — it just weighs it against everything else you insisted on carrying forward.
+
+## What a production system needs beyond prompts
+
+A demo needs a prompt and a model call. A production system needs the machinery around them:
+
+- **Checkpoints** — a durable write after each meaningful step, so a crash costs one step rather than the whole task.
+- **Resumable state** — the ability to reload a task hours later, after a restart or a handover, and continue rather than restart.
+- **Validation** — schema checks on every tool call and every state transition, so a malformed model output fails loudly at the boundary instead of quietly corrupting the run.
+- **Observability** — traces you can filter by task, step, and outcome. Not log lines; structured events tied to the state they changed.
+- **Policy controls** — business rules enforced in code, evaluated outside the model, recorded in the decisions list.
+- **A path for human intervention** — an explicit blocked state, a queue a person can see, and a way to resume the workflow after they act.
+
+None of these are AI features. They are the ordinary requirements of reliable business software, and skipping them is what makes an agent feel fragile even when the model is performing well.
+
+## Who is allowed to do what
+
+The principle I keep coming back to is a division of authority:
+
+> The AI can understand the language and recommend an action. The system must control the money, inventory, permissions, policies, and final execution.
+
+Consider a refund request. The agent is genuinely good at the hard part: reading a frustrated, ambiguous message and working out that this is a refund request for a specific order, and that the customer is citing a delivery delay. That is language understanding, and it is what the model should be doing.
+
+What the agent should not do is decide the refund. Whether the order is inside the refund window, whether the delay was the carrier's fault, whether this customer has already had two goodwill credits this quarter, what the approval threshold is above a certain amount — those are policy evaluations against real records, and they belong in code that runs the same way every time and leaves a trace.
+
+So the agent proposes: *refund order #1042, £84, reason: delivery delay*. The system evaluates the policy, finds the amount is above the auto-approve threshold, sets `blockedOn: 'human_approval'`, and queues it. A supervisor approves. The system executes the refund, appends the decision to the audit log, and hands control back to the agent to tell the customer.
+
+The model never touched the money. It did the part it is good at, and the boundary is drawn where correctness stops being a matter of interpretation.
+
+## The actual shift
+
+A good demo produces an impressive answer.
+
+A production system must also explain what happened, continue from where it stopped, and recover safely when something goes wrong. Those three requirements — explicability, resumability, recoverability — are not features you add at the end. They are consequences of how you decided to hold state on the first day.
+
+That is the real shift: from treating an AI agent as a chatbot to engineering it as reliable business software.

--- a/contents/engineering/sync-or-async-for-an-ai-support-chatbot.md
+++ b/contents/engineering/sync-or-async-for-an-ai-support-chatbot.md
@@ -1,0 +1,116 @@
+---
+title: Sync or async for an AI support chatbot
+date: 2026-08-02
+draft: true
+tags: [AI Agents, System Architecture, Backend Engineering, LLM]
+excerpt: If customer A is waiting for the LLM, does customer B have to wait too? The answer is an architecture decision, and it matters long before you have a thousand customers.
+---
+
+When designing an AI customer-support chatbot, should we use a synchronous or asynchronous architecture?
+
+It is easy to turn this into a question about which is more modern. It is more useful to start with something concrete:
+
+> If customer A is waiting for an LLM to generate a response, does customer B also have to wait?
+
+The answer depends entirely on how concurrency is handled, and the two architectures answer it differently.
+
+## What a synchronous worker actually does
+
+With a single synchronous worker, a request looks like this:
+
+```
+Customer A → Retrieve data → Call the LLM → Wait → Return the response
+```
+
+Until that request completes, the worker cannot touch customer B. Customer B — and everyone after them — waits in the queue. Not because the system is busy, but because the one thing that could serve them is sitting idle, blocked on a network call.
+
+Adding workers increases capacity in the obvious way: four workers process four requests concurrently. That is a real improvement, and for a while it is enough. But the ceiling is still there. Once all four workers are waiting on OpenAI, a database, a CRM, or an order system, request five waits — even though every one of those four processes is doing nothing but holding a socket open.
+
+That is the part worth sitting with. The bottleneck in a synchronous chatbot is usually not computation. It is workers parked on I/O.
+
+## What asynchronous changes
+
+An asynchronous architecture breaks the coupling between "this request is in flight" and "a worker is dedicated to it". While one request waits on an external service, the worker gets on with others:
+
+- Customer A is waiting for the LLM
+- Customer B is retrieving an order
+- Customer C is receiving a streamed response
+
+An event loop coordinates all three without assigning a worker to each waiting request. When A's response arrives, its coroutine resumes where it left off.
+
+This matters for AI support specifically because chatbots are close to a pure I/O-bound workload. Look at where the time actually goes:
+
+- LLM APIs
+- Vector databases and knowledge bases
+- CRM and order systems
+- Inventory, delivery, and pricing services
+- Conversation logging and analytics
+
+Almost all of it is waiting on somebody else's network. That is the exact shape of problem async was built for.
+
+## What asynchronous does not change
+
+Two clarifications, because both get lost in the enthusiasm.
+
+**Async does not make the LLM faster.** If a completion takes four seconds, it takes four seconds. Customer A's wait is unchanged. What improves is concurrency and resource utilisation — the system can serve B and C during those four seconds instead of standing still.
+
+**An async endpoint can still block.** This is the caveat that catches people, and it is worth being precise about it. Declaring a handler `async` does not make anything inside it non-blocking:
+
+```python
+@app.post("/chat")
+async def chat(req: ChatRequest):
+    order = db.query(...)          # synchronous driver — stalls the event loop
+    reply = openai_client.chat(...)  # blocking HTTP — stalls it again
+    return reply
+```
+
+That endpoint is worse than the synchronous version. A blocking call inside a coroutine does not just delay that request; it freezes the event loop, which means it freezes every other request the loop was juggling.
+
+The version that behaves the way you intended:
+
+```python
+@app.post("/chat")
+async def chat(req: ChatRequest):
+    order = await db.fetch(...)      # async driver
+    reply = await client.chat(...)   # async HTTP client
+    return reply
+```
+
+The same trap applies to CPU-bound work. Parsing a large PDF, computing embeddings locally, or resizing an image inside a coroutine will hold the loop for the whole duration. That work belongs in a thread pool or a separate process, not on the event loop.
+
+The rule is simple to state and easy to violate: everything in an async path must be awaitable or offloaded. One synchronous database driver is enough to undo the entire design.
+
+## Four components, four different problems
+
+For a production AI support system I would generally reach for four things. They are frequently discussed as if they were alternatives, but each solves a distinct problem:
+
+| Component | Solves | Does not solve |
+|---|---|---|
+| **Async API** | many concurrent connections without a worker each | model latency |
+| **Response streaming** | perceived waiting time | total time to completion |
+| **Multiple workers** | CPU parallelism, fault isolation | blocking inside a worker |
+| **Background queues** | non-immediate work off the request path | anything the customer is waiting for |
+
+Streaming deserves a note. It changes no throughput number at all, and it is often the single largest improvement to how the product feels. First token in 400 ms reads as responsive; four seconds of silence followed by a complete answer reads as broken, even though the second one finished at the same moment.
+
+Background queues deserve one too. Conversation logging, analytics, file processing, CRM sync — none of it needs to happen before the customer sees a reply. Moving it off the request path is usually the cheapest latency win available, and it is independent of whether the API is sync or async.
+
+## Synchronous is not the wrong answer
+
+For a low-traffic MVP with simple workflows, synchronous is easier to build, easier to test, and considerably easier to debug. Stack traces are linear. There is no event loop to reason about, no question of which library is secretly blocking. If you are validating whether customers even want the thing, that clarity is worth more than throughput you do not yet need.
+
+The calculus changes once the chatbot integrates multiple markets, knowledge bases, orders, inventory, logistics, and CRM systems. Every integration adds another external call, another few hundred milliseconds of waiting, and another opportunity for a worker to sit blocked. At that point the async architecture stops being an optimisation and starts being the thing that lets you scale without linearly buying processes.
+
+It is also much easier to start async than to retrofit it. Migrating a mature synchronous codebase means replacing every driver and HTTP client in the request path, and finding the ones you missed in production.
+
+## The question that matters
+
+The useful question is not:
+
+> Is sync or async more advanced?
+
+It is:
+
+> When 10, 100, or 1,000 customers arrive simultaneously, can the system serve them reliably without wasting workers while waiting for external services?
+
+Answer that honestly for your traffic and your integration count, and the architecture decision mostly makes itself.


### PR DESCRIPTION
Adds a two-part series under a new `engineering` category, developed from two source drafts.

## Posts

**`contents/engineering/an-ai-agent-does-not-need-to-remember-everything.md`** — dated 1 Aug, publishes on merge.

Argues that reliability in agents is a state problem rather than a memory problem. Draws the distinction between conversation history, memory, workflow state and audit log (as a comparison table), gives the operational-state object as a TypeScript interface with evidence held by reference rather than by value, covers the three failure modes of one large context window, and closes on the division of authority — the model recommends, the system executes — illustrated with a refund approval flow.

**`contents/engineering/sync-or-async-for-an-ai-support-chatbot.md`** — dated 2 Aug, held as a draft.

Works through concurrency for I/O-bound chatbots from the "if customer A is waiting, does customer B wait?" framing. Covers what a blocked synchronous worker actually costs, what an event loop changes, the two things async does *not* fix, the blocking-driver trap with before/after Python examples, and a table separating what async APIs, streaming, multiple workers and background queues each solve.

## Scheduling

The second post carries `draft: true`. `getPosts` in `src/lib/posts.ts` filters on the `draft` flag and not on a future date, so without the flag a post dated 2 Aug would go live as soon as this merged. Flipping it to `false` (or deleting the line) and pushing is the publish step for the second post.

## Conventions followed

- Category comes from the folder, so both files sit under `contents/engineering/`.
- `date` is set explicitly in frontmatter — `scripts/git-dates.mjs` would otherwise date both from their first commit.
- `title` and `excerpt` are set in frontmatter, so neither body opens with an H1 and neither excerpt is derived.
- Tags overlap across the two posts (`AI Agents`, `System Architecture`), so `relatedTo` links them to each other in addition to the shared-category score.

## Verification

`npm run check` — 0 errors, 0 warnings across 25 files; all 10 theme blocks pass WCAG AA.

`npm run build` — 11 pages built, Pagefind indexed. Confirmed in `dist/`: the first post, its OG card and its category and tag pages are generated, and the draft produces no page and no tag routes for its unshared tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZB9NgghKyNubqdQaJoJ3H

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZB9NgghKyNubqdQaJoJ3H)_