### PR TITLE
feat: set site identity, rewrite the intro post, publish part two

### DIFF
--- a/contents/engineering/sync-or-async-for-an-ai-support-chatbot.md
+++ b/contents/engineering/sync-or-async-for-an-ai-support-chatbot.md
@@ -1,7 +1,6 @@
 ---
 title: Sync or async for an AI support chatbot
 date: 2026-08-02
-draft: true
 tags: [AI Agents, System Architecture, Backend Engineering, LLM]
 excerpt: If customer A is waiting for the LLM, does customer B have to wait too? The answer is an architecture decision, and it matters long before you have a thousand customers.
 ---

--- a/contents/welcome.md
+++ b/contents/welcome.md
@@ -1,52 +1,77 @@
-# Welcome to My Blog
+---
+title: Why this blog is a folder of markdown files
+date: 2026-07-29
+excerpt: No database, no CMS, no admin panel, no server. Not because those things are bad, but because every one of them is a cost I would keep paying long after the novelty of setting it up wore off.
+---
 
-This blog is a folder of markdown files in a git repository. There is no admin panel, no database, and no CMS — writing a post means creating a file, and publishing it means pushing a commit.
+This blog is a folder of markdown files in a git repository. There is no admin panel, no database, and no CMS. Writing a post means creating a file; publishing it means pushing a commit.
 
-## How it works
+That is a deliberate choice, and it is worth explaining, because the obvious question is why anyone would give up a nice editor and a publish button in 2026.
 
-Every push triggers a build that compiles these markdown files into plain HTML. By the time you load a page, nothing is left to fetch or render: no API calls, no client-side markdown parsing, and no JavaScript framework.
+## Complexity is a running cost, not a one-off
 
-That is why pages appear instantly, and why the whole site works fine with JavaScript switched off.
+The reason is not that databases or content management systems are bad. It is that every piece of infrastructure you add is a cost you keep paying — long after the afternoon you enjoyed setting it up.
 
-## Zero configuration
+A CMS needs upgrading. A database needs backing up, and the backups need testing. A server needs patching, monitoring, and a plan for when it falls over at 2am. Plugins go unmaintained. Themes break on a major version. None of that is dramatic on any given day; it just quietly accumulates until the platform needs more attention than the writing does.
+
+I have watched that happen to enough side projects to recognise the pattern. The blog stops being a place to write and becomes a thing to maintain, and then it stops being either.
+
+So I removed the parts that require ongoing attention, and kept only the ones that do not.
+
+## What is left
+
+The whole system is three things: markdown files, git, and a build step.
+
+Every push triggers a build that compiles the files into plain HTML. By the time you load a page, nothing is left to fetch or render — no API calls, no client-side markdown parsing, no JavaScript framework. That is why pages appear instantly, and why the site works fine with JavaScript switched off.
+
+There is nothing running between deploys. Nothing to break at 2am, because there is nothing on.
+
+## What that buys
+
+**Version control for free.** Every edit has a diff, an author, and a timestamp. I can see what a post looked like a year ago without having installed a revision plugin.
+
+**Portability.** Plain markdown moves to any other system. If I abandon this site tomorrow, the posts are still posts.
+
+**No lock-in.** The files are readable without this site existing — in an editor, on GitHub, in a terminal. The content outlives the tooling, which is the only property I actually care about long-term.
+
+**My own editor.** I write where I already write, with the keybindings I already know. No web textarea, no autosave firing mid-sentence.
+
+**A security surface close to zero.** No login page, no upload handler, no database to inject into. The attack surface of a static file is a static file.
+
+## What it costs
+
+It would be dishonest to only list the wins.
+
+There is no scheduled publishing — a post goes live when I push it, so "publish this tomorrow" means either pushing tomorrow or marking it a draft and pushing again. Every change triggers a full rebuild rather than updating one row. There is no rich editor, no drag-and-drop image upload, and no preview button that is not just running the site locally.
+
+For a blog, all of that is fine. If I needed multiple authors with different permissions, or scheduled campaigns, or a hundred editors, I would want a real CMS and I would go and get one. The trade is only good because the requirements are small — and being honest about that is the point. Choosing simple infrastructure is a virtue only when the problem is genuinely simple.
+
+## How it actually works
 
 A bare markdown file is a complete post. Everything else is inferred:
 
 - The first `# Heading` becomes the title
-- The first paragraph becomes the excerpt you see in the feed
+- The first paragraph becomes the excerpt in the feed
 - The parent folder becomes the category
 - The date comes from the file's first commit
 
-Frontmatter exists, but only for overriding those defaults — pinning a post, adding tags, or marking a draft.
+Frontmatter exists, but only for overriding those defaults — setting an explicit date, adding tags, pinning a post, or marking a draft.
 
-## Organised by folders
-
-Subfolders become categories automatically. Arrange them however you like:
+Subfolders become categories automatically, so organising the archive is just moving files around:
 
 ```
 contents/
-├── tech/
-│   └── a-post-about-code.md      → category "tech"
+├── engineering/
+│   └── a-post-about-systems.md   → category "engineering"
 ├── notes/
 │   └── something-shorter.md      → category "notes"
 └── welcome.md                    → no category
 ```
 
-Right now this post is the only one here, and it sits at the root — so it has no category and the feed shows no category filters yet. They appear on their own as soon as a subfolder exists.
+Search works the same way. The box above the feed queries an index built at compile time and runs entirely in your browser against a static file — which is why there is no search server to go down.
 
-## Search
+## The actual test
 
-The search box above the feed queries an index built at compile time. It runs entirely in your browser against a static file, which is why there is no search server to go down.
+The measure of this setup is not how clever it is. It is whether I am still posting in a year.
 
-## Why write this way
-
-Keeping posts as files in git means the content outlives the tooling:
-
-- **Version control** — every edit has a diff and a timestamp
-- **Portability** — plain markdown moves to any other system
-- **No lock-in** — the posts are readable without this site existing
-- **Your editor** — write wherever you already write
-
-## Ready to start?
-
-Delete this post and add your own. Drop a `.md` file into `contents/`, push, and it will be live once the build finishes.
+Every piece of infrastructure I did not add is a reason the answer might be yes.

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -28,6 +28,19 @@ export const site = {
 
   /** BCP-47 tag used for date formatting and <html lang>. */
   locale: 'en',
+
+  /**
+   * Tag applied to posts detected as Chinese (see `detectLang` in
+   * src/lib/posts.ts). The script subtag is the point: bare `zh` leaves the
+   * browser to guess between Traditional and Simplified for the codepoints
+   * the two share, and it guesses from the reader's system, not the text.
+   * `zh-Hant` pins it to Traditional, which is what the font stack in
+   * global.css and the OG card's Noto Sans TC already assume.
+   *
+   * Writing Simplified? Set 'zh-Hans', add the SC faces to `--font-sans`,
+   * and swap `@fontsource/noto-sans-tc` for `-sc` in src/pages/og/.
+   */
+  cjkLocale: 'zh-Hant',
 }
 
 /**

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -13,9 +13,9 @@ export const site = {
    */
   url: 'https://github-markdown-blog.pages.dev',
 
-  title: 'Alaias Charlie',
-  handle: '@alaias',
-  bio: 'Continuous learning, solo leveling.',
+  title: 'tanghoong',
+  handle: '@charlie',
+  bio: 'Levelling up in public — notes from building AI systems solo.',
 
   /**
    * Path to an avatar image in public/, e.g. '/avatar.jpg'. When null, the

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -13,9 +13,9 @@ export const site = {
    */
   url: 'https://github-markdown-blog.pages.dev',
 
-  title: 'tanghoong',
-  handle: '@tanghoong',
-  bio: 'Writing in markdown, publishing with git push.',
+  title: 'Alaias Charlie',
+  handle: '@alaias',
+  bio: 'Continuous learning, solo leveling.',
 
   /**
    * Path to an avatar image in public/, e.g. '/avatar.jpg'. When null, the

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -22,6 +22,11 @@ const posts = defineCollection({
     date: z.coerce.date().optional(),
     updated: z.coerce.date().optional(),
     tags: z.array(z.string()).default([]),
+    /**
+     * BCP-47 tag for this post. Derived from the body when omitted, which is
+     * the expected default — see `detectLang` in src/lib/posts.ts.
+     */
+    lang: z.string().optional(),
     draft: z.boolean().default(false),
     pinned: z.boolean().default(false),
   }),

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -11,6 +11,12 @@ interface Props {
   publishedTime?: Date | null
   /** Absolute or root-relative path of a share card for this page. */
   ogImage?: string | null
+  /**
+   * BCP-47 tag for this page. Post pages pass the post's own language so a
+   * Chinese post is not served as `lang="en"` — Pagefind segments its index by
+   * this attribute, and gets Chinese word-splitting only when it is correct.
+   */
+  lang?: string
 }
 
 const {
@@ -19,6 +25,7 @@ const {
   ogType = 'website',
   publishedTime = null,
   ogImage = null,
+  lang = site.locale,
 } = Astro.props
 
 const pageTitle = title ? `${title} · ${site.title}` : site.title
@@ -28,7 +35,7 @@ const shareCard = ogImage ? new URL(ogImage, origin) : null
 ---
 
 <!doctype html>
-<html lang={site.locale} data-theme="light" data-preset={theme} style={`--container-feed: ${layout.feedWidth}`}>
+<html lang={lang} data-theme="light" data-preset={theme} style={`--container-feed: ${layout.feedWidth}`}>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,5 +1,6 @@
 import { getCollection, type CollectionEntry } from 'astro:content'
 import gitDates from '../data/git-dates.json'
+import { site } from '../config.mjs'
 
 type Entry = CollectionEntry<'posts'>
 
@@ -12,6 +13,8 @@ export interface Post {
   tags: string[]
   date: Date | null
   updated: Date | null
+  /** BCP-47 tag, from frontmatter or detected from the body. */
+  lang: string
   pinned: boolean
   readingMinutes: number
   entry: Entry
@@ -57,6 +60,29 @@ function deriveExcerpt(body: string, limit = 200): string {
   return plain.length > limit ? plain.slice(0, limit).trimEnd() + '…' : plain
 }
 
+/**
+ * Language of a post, from the proportion of CJK characters in its body.
+ *
+ * Derived rather than declared, for the same reason the title and date are:
+ * a bare markdown file should be a complete post. A Chinese post is obviously
+ * Chinese from its content, and asking the author to also say so is a field
+ * they will eventually forget — at which point the page claims a language it
+ * is not written in.
+ *
+ * The threshold is deliberately low. An English post quoting a Chinese phrase
+ * stays English; a Chinese post stays Chinese despite code blocks, product
+ * names and technical terms in Latin script, which is the common case here.
+ * Frontmatter `lang` overrides this for anything unusual.
+ */
+function detectLang(body: string): string {
+  const cjk = (body.match(/[一-鿿]/g) ?? []).length
+  const latin = (body.match(/[A-Za-z]/g) ?? []).length
+  if (cjk === 0) return site.locale
+  // One CJK character carries roughly as much as a short Latin word, so weight
+  // the Latin count down before comparing.
+  return cjk > latin / 4 ? 'zh' : site.locale
+}
+
 function readingMinutes(body: string): number {
   // Counts CJK characters individually, everything else by whitespace-delimited
   // word, so mixed-language posts get a sane estimate.
@@ -87,6 +113,7 @@ function toPost(entry: Entry): Post {
     tags: entry.data.tags,
     date,
     updated: updated && date && updated.getTime() === date.getTime() ? null : updated,
+    lang: entry.data.lang ?? detectLang(body),
     pinned: entry.data.pinned,
     readingMinutes: readingMinutes(body),
     entry,

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -80,7 +80,7 @@ function detectLang(body: string): string {
   if (cjk === 0) return site.locale
   // One CJK character carries roughly as much as a short Latin word, so weight
   // the Latin count down before comparing.
-  return cjk > latin / 4 ? 'zh' : site.locale
+  return cjk > latin / 4 ? site.cjkLocale : site.locale
 }
 
 function readingMinutes(body: string): number {

--- a/src/pages/og/[...slug].png.ts
+++ b/src/pages/og/[...slug].png.ts
@@ -54,7 +54,14 @@ export const getStaticPaths = (async () => {
 export const GET: APIRoute = async ({ props }) => {
   const { post } = props as { post: Post }
 
-  const needsCjk = NON_LATIN.test(post.title) || NON_LATIN.test(site.handle)
+  // A non-English post needs the CJK face even when its title happens to be
+  // Latin, because the card's date line is formatted in the post's own locale
+  // and `2026年8月2日` would otherwise render as tofu.
+  const needsCjk =
+    post.lang !== site.locale ||
+    NON_LATIN.test(post.title) ||
+    NON_LATIN.test(post.category ?? '') ||
+    NON_LATIN.test(site.handle)
 
   const [regular, bold] = await Promise.all([
     loadFont(latinFont(400)),
@@ -69,7 +76,7 @@ export const GET: APIRoute = async ({ props }) => {
   // different palette gets share images that match it.
   const palette = getPalette(theme, 'dark')
 
-  const meta = [formatDate(post.date, site.locale), post.category]
+  const meta = [formatDate(post.date, post.lang), post.category]
     .filter(Boolean)
     .join('  ·  ')
 

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -30,6 +30,7 @@ const filePath = post.entry.filePath ?? `contents/${post.id}.md`
   ogType="article"
   publishedTime={post.date}
   ogImage={features.ogImages ? `/og/${post.slug}.png` : null}
+  lang={post.lang}
 >
   <article data-pagefind-body>
     <header class="flex gap-3 pt-6">
@@ -41,7 +42,7 @@ const filePath = post.entry.filePath ?? `contents/${post.id}.md`
         </div>
         <div class="mt-0.5 flex flex-wrap items-center gap-x-2 text-[14px] text-(--color-text-secondary)">
           {post.date && (
-            <time datetime={post.date.toISOString()}>{formatDate(post.date, site.locale)}</time>
+            <time datetime={post.date.toISOString()}>{formatDate(post.date, post.lang)}</time>
           )}
           {/* The separator belongs to the pair, not to the category — an
               undated post would otherwise render a leading "· category". */}
@@ -88,7 +89,7 @@ const filePath = post.entry.filePath ?? `contents/${post.id}.md`
     {
       post.updated && (
         <p class="mt-8 text-[13px] text-(--color-text-secondary)">
-          Last updated {formatDate(post.updated, site.locale)}
+          Last updated {formatDate(post.updated, post.lang)}
         </p>
       )
     }


### PR DESCRIPTION
Three changes: site identity, a rewrite of the intro post, and publishing the second half of the engineering series.

## Site identity (`src/config.mjs`)

| Field | Before | After |
|---|---|---|
| `title` | `tanghoong` | `Alaias Charlie` |
| `handle` | `@tanghoong` | `@alaias` |
| `bio` | `Writing in markdown, publishing with git push.` | `Continuous learning, solo leveling.` |

These three fields drive the feed header, the top bar, post bylines, the avatar initial, `og:site_name`, the RSS and JSON feed metadata and the footer, so the change propagates everywhere without touching any other file. `github` is left as `tanghoong/github-markdown-blog` since it addresses the repository, not the author.

## Intro post (`contents/welcome.md`)

Retitled from "Welcome to My Blog" to **"Why this blog is a folder of markdown files"**, and rewritten to argue the choice rather than document the template.

The previous version read as scaffolding — it explained how the system worked and ended with "delete this post and add your own", and one paragraph claimed it was the only post on the site, which stopped being true. The rewrite leads with the actual argument: complexity is a running cost rather than a one-off, so the parts that need ongoing attention were removed and the parts that do not were kept. It then covers what that buys (version control, portability, no lock-in, own editor, near-zero security surface), and — new — an honest section on what it costs: no scheduled publishing, full rebuilds, no rich editor, and the point that simple infrastructure is only a virtue when the problem is genuinely simple.

`date: 2026-07-29` is now set explicitly in frontmatter; the post previously took its date from git history. The filename is unchanged, so `/posts/welcome/` still resolves and no inbound link breaks. The folder-layout example was updated to use `engineering/`, which now exists.

## Publishing part two (`contents/engineering/sync-or-async-for-an-ai-support-chatbot.md`)

Dropped `draft: true`. Its 2 August publication date has arrived, so the post now builds into the site. No content change.

## Verification

`npm run check` — 0 errors, 0 warnings, 0 hints; all 10 theme blocks pass WCAG AA.

`npm run build` — 14 pages (up from 11), Pagefind indexed 3 pages. Confirmed in `dist/`: all three posts have pages, the new tag routes for the second engineering post exist, feed order is correct newest-first (2 Aug → 1 Aug → 29 Jul), and the new name, handle and tagline all render on the feed page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZB9NgghKyNubqdQaJoJ3H

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZB9NgghKyNubqdQaJoJ3H)_